### PR TITLE
Add Flake support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Add this repo as a flake input. Now you can import the module with:
 .. code-block:: nix
 
   { inputs, ... }: {
-    imports = [inputs.shabitica.nixosModules."x86_64-linux".default]; # change "x86_64-linux" to your actual system
+    imports = [ inputs.shabitica.nixosModules.default ];
     #... add your configuration
   }
 

--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,21 @@ make the browser client less painful on mobile phones.
 Getting started on NixOS
 ------------------------
 
+Using Flakes
+````````````
+
+Add this repo as a flake input. Now you can import the module with:
+
+.. code-block:: nix
+
+  { inputs, ... }: {
+    imports = [inputs.shabitica.nixosModules."x86_64-linux".default]; # change "x86_64-linux" to your actual system
+    #... add your configuration
+  }
+
+Using Channels
+``````````````
+
 Simply adding the path of the source to the ``imports`` list of your `NixOS
 configuration`_ (typically ``/etc/nixos/configuration.nix``) will start a local
 instance.

--- a/deps/generated/node-packages.nix
+++ b/deps/generated/node-packages.nix
@@ -20667,7 +20667,7 @@ in
     packageName = "vuejs-datepicker";
     version = "0.9.21";
     src = fetchgit {
-      url = "git://github.com/habitrpg/vuejs-datepicker.git";
+      url = "https://github.com/habitrpg/vuejs-datepicker.git";
       rev = "5d237615463a84a23dd6f3f77c6ab577d68593ec";
       sha256 = "26ab3d799bb9b3c3eab22b2de43378cf1039191b5dd3a58fac5fb6e95f31d5f8";
     };

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1622516815,
+        "narHash": "sha256-ZjBd81a6J3TwtlBr3rHsZspYUwT9OdhDk+a/SgSEf7I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7e9b0dff974c89e070da1ad85713ff3c20b0ca97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1622516815,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,16 @@
   description = "shabitica flake";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/21.05";
 
-  outputs = { self, nixpkgs, ... }@inputs: {
-    nixosModules = builtins.mapAttrs
-      (system: pkgs: {
-        default =
-          { lib, config, ... }: {
-            imports = [
-              (import ./default.nix {
-                inherit lib config;
-                pkgs = import nixpkgs { inherit system; };
-              })
-            ];
+  outputs = { nixpkgs, ... }: {
+    nixosModules.default = { lib, config, ... }: {
+      imports = [
+        (import ./default.nix {
+          inherit lib config;
+          pkgs = import nixpkgs {
+            inherit (config.nixpkgs.localSystem) system;
           };
-      })
-      nixpkgs.legacyPackages;
+        })
+      ];
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,11 @@
 
   outputs = { nixpkgs, ... }: {
     nixosModules.default = { lib, config, ... }: {
-      imports = [
-        (import ./default.nix {
-          inherit lib config;
-          pkgs = import nixpkgs {
-            inherit (config.nixpkgs.localSystem) system;
-          };
-        })
-      ];
+      imports = [ ./modules ];
+
+      shabitica.pinnedPkgs = import nixpkgs {
+        inherit (config.nixpkgs.localSystem) system;
+      };
     };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixosModules.default = { lib, config, ... }: {
       imports = [ ./modules ];
 
-      shabitica.pinnedPkgs = import nixpkgs {
+      shabitica.pinnedPkgs = {...}: import nixpkgs {
         inherit (config.nixpkgs.localSystem) system;
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,20 @@
 {
   description = "shabitica flake";
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/21.05";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
-  outputs =
-    { self, flake-utils, ... }@inputs:
-     flake-utils.lib.eachDefaultSystem (system:{
-      nixosModules.default = (
-        {
-          config,
-          lib,
-          pkgs,
-          ...
-        }:
-        {
-          imports = [
-            (import ./default.nix { pkgs = (import inputs.nixpkgs { system = system; }); inherit lib config;})
-          ];
-        }
-      );
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/21.05";
 
-    });
+  outputs = { self, nixpkgs, ... }@inputs: {
+    nixosModules = builtins.mapAttrs
+      (system: pkgs: {
+        default =
+          { lib, config, ... }: {
+            imports = [
+              (import ./default.nix {
+                inherit lib config;
+                pkgs = import nixpkgs { inherit system; };
+              })
+            ];
+          };
+      })
+      nixpkgs.legacyPackages;
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "shabitica flake";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/21.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    { self, flake-utils, ... }@inputs:
+     flake-utils.lib.eachDefaultSystem (system:{
+      nixosModules.default = (
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        {
+          imports = [
+            (import ./default.nix { pkgs = (import inputs.nixpkgs { system = system; }); inherit lib config;})
+          ];
+        }
+      );
+
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,6 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/21.05";
 
   outputs = { nixpkgs, ... }: {
-    nixosModules.default = { lib, config, ... }: {
-      imports = [ ./modules ];
-
-      shabitica.pinnedPkgs = {...}: import nixpkgs {
-        inherit (config.nixpkgs.localSystem) system;
-      };
-    };
+    nixosModules.default = (args: import ./modules (args // { pkgs = import nixpkgs { system = args.config.nixpkgs.localSystem.system; }; }) );
   };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,10 +1,12 @@
 # NOTE: When adding another module argument here, do not forget to provide
 #       defaults in ../default.nix, so that it will cope well with
 #       "nix-env -q".
-{ config, pkgs, lib, ... }:
+{ config, lib, ... }:
 
 let
   cfg = config.shabitica;
+
+  pkgs = cfg.pinnedPkgs;
 
   mongodb = pkgs.callPackage ../pkgs/mongodb {};
 
@@ -19,7 +21,7 @@ let
   latestDbVersion = lib.length migrations;
 
 in {
-  imports = [ (import ./imageproxy.nix { inherit config pkgs lib; }) ];
+  imports = [ ./imageproxy.nix ];
 
   options.shabitica = {
     hostName = lib.mkOption {
@@ -28,6 +30,14 @@ in {
       example = "shabitica.example.org";
       description = "The host name to use for Shabitica.";
     };
+
+
+    options.shabitica.pinnedPkgs = lib.mkOption {
+      # TODO i don't know the type of pkgs, 
+      type = lib.types.anything;
+      description = "Version of nixpkgs used by the Shabitica modules";
+    };
+
 
     adminMailAddress = lib.mkOption {
       type = lib.types.str;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -32,7 +32,7 @@ in {
     };
 
 
-    options.shabitica.pinnedPkgs = lib.mkOption {
+    pinnedPkgs = lib.mkOption {
       # TODO i don't know the type of pkgs, 
       type = lib.types.anything;
       description = "Version of nixpkgs used by the Shabitica modules";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -19,7 +19,7 @@ let
   latestDbVersion = lib.length migrations;
 
 in {
-  imports = [ ./imageproxy.nix ];
+  imports = [ (import ./imageproxy.nix { inherit config pkgs lib; }) ];
 
   options.shabitica = {
     hostName = lib.mkOption {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,7 +6,7 @@
 let
   cfg = config.shabitica;
 
-  pkgs = cfg.pinnedPkgs;
+  pkgs = cfg.pinnedPkgs {};
 
   mongodb = pkgs.callPackage ../pkgs/mongodb {};
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,12 +1,10 @@
 # NOTE: When adding another module argument here, do not forget to provide
 #       defaults in ../default.nix, so that it will cope well with
 #       "nix-env -q".
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.shabitica;
-
-  pkgs = cfg.pinnedPkgs {};
 
   mongodb = pkgs.callPackage ../pkgs/mongodb {};
 
@@ -21,7 +19,7 @@ let
   latestDbVersion = lib.length migrations;
 
 in {
-  imports = [ ./imageproxy.nix ];
+  imports = [ (args: import ./imageproxy.nix (args // {inherit pkgs; })) ];
 
   options.shabitica = {
     hostName = lib.mkOption {
@@ -30,14 +28,6 @@ in {
       example = "shabitica.example.org";
       description = "The host name to use for Shabitica.";
     };
-
-
-    pinnedPkgs = lib.mkOption {
-      # TODO i don't know the type of pkgs, 
-      type = lib.types.anything;
-      description = "Version of nixpkgs used by the Shabitica modules";
-    };
-
 
     adminMailAddress = lib.mkOption {
       type = lib.types.str;
@@ -471,7 +461,7 @@ in {
           hasEtagPatch = let
             patches = config.services.nginx.package.patches or [];
             matchEtagPatch = builtins.match ".*nix-etag.*patch";
-          in lib.any (p: matchEtagPatch p.name != null) patches;
+          in lib.any (p: matchEtagPatch (toString p) != null) patches;
 
           # Workaround for https://github.com/NixOS/nixpkgs/issues/25485
           storeDirWorkaround = ''

--- a/modules/imageproxy.nix
+++ b/modules/imageproxy.nix
@@ -1,7 +1,8 @@
-{ config, pkgs, lib, ... }:
+{ config, lib, ... }:
 
 let
   cfg = config.shabitica;
+  pkgs = cfg.pinnedPkgs;
 
   go-camo = pkgs.callPackage ../pkgs/go-camo {};
   go-camo-bin = lib.getBin go-camo;

--- a/modules/imageproxy.nix
+++ b/modules/imageproxy.nix
@@ -2,7 +2,7 @@
 
 let
   cfg = config.shabitica;
-  pkgs = cfg.pinnedPkgs;
+  pkgs = cfg.pinnedPkgs {};
 
   go-camo = pkgs.callPackage ../pkgs/go-camo {};
   go-camo-bin = lib.getBin go-camo;

--- a/modules/imageproxy.nix
+++ b/modules/imageproxy.nix
@@ -1,9 +1,7 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.shabitica;
-  pkgs = cfg.pinnedPkgs {};
-
   go-camo = pkgs.callPackage ../pkgs/go-camo {};
   go-camo-bin = lib.getBin go-camo;
 


### PR DESCRIPTION
This repository is quite out of date. With a flake.nix it can be imported in nixos-unstable or a newer release with pkgs for shabitica pinned at 21.05

i also changed git:// to https:// in the generated file for the node packages. 

fixes #11 